### PR TITLE
feat: expand tilde to home directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ name = "netrc"
 path = "src/lib.rs"
 
 [dependencies]
+shellexpand = { version = "3.1.0", features = ["base-0", "tilde", "path"], default-features = false }
 thiserror = "1.0.56"
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,9 @@ impl Netrc {
     /// Look up the `NETRC` environment variable if it is defined else use the .netrc (or _netrc
     /// file on windows) in the user's home directory.
     pub fn get_file() -> Option<PathBuf> {
-        let env_var = std::env::var("NETRC").map(PathBuf::from);
+        let env_var = std::env::var("NETRC")
+            .map(PathBuf::from)
+            .map(|f| shellexpand::path::tilde(&f).into_owned());
 
         #[cfg(windows)]
         let default = std::env::var("USERPROFILE")


### PR DESCRIPTION
This extends the `NETRC` env variable to a full path when starting with ~. This works on both windows and unix. 
closes #4 