### PR TITLE
fix: properly check for error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,12 +159,12 @@ password hY5>yKqU&$vq&0
 
     #[test]
     fn test_from_file_failed() {
-        assert_eq!(
-            Netrc::from_file(Path::new("/netrc/file/not/exists/on/no/netrc"))
-                .unwrap_err()
-                .to_string(),
-            "I/O error: No such file or directory (os error 2)"
-        );
+        let res = Netrc::from_file(Path::new("/netrc/file/not/exists/on/no/netrc"));
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            Error::Io(e) => assert_eq!(e.kind(), ErrorKind::NotFound),
+            Error::Parsing { .. } => panic!("wrong error"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
`test_from_file_failed()` checks that a missing `netrc` file results in the proper error, i.e. `Error::Io(std::io::ErrorKind::NotFound`. It tries to do so by checking the string representation of the error, which is not portable in few ways: the error string for `ENOENT`, and the value of `errno`.

Instead, check the error manually, asserting it is the type wanted.