### PR TITLE
Fix comment handling by tracking line starts in the lexer

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -5,6 +5,7 @@ pub struct Lex<'a> {
     pub lineno: u32,
     pub instream: Chars<'a>,
     pub pushback: VecDeque<String>,
+    pub at_line_start: bool,
 }
 
 impl<'a> Lex<'a> {
@@ -13,6 +14,7 @@ impl<'a> Lex<'a> {
             lineno: 1,
             instream: content.chars(),
             pushback: VecDeque::new(),
+            at_line_start: true,
         }
     }
 
@@ -20,6 +22,9 @@ impl<'a> Lex<'a> {
         let ch = self.instream.next();
         if ch == Some('\n') {
             self.lineno += 1;
+            self.at_line_start = true;
+        } else if ch.is_some_and(|c| !c.is_whitespace()) {
+            self.at_line_start = false;
         }
         ch
     }
@@ -28,6 +33,7 @@ impl<'a> Lex<'a> {
         let mut s = String::new();
         for ch in &mut self.instream {
             if ch == '\n' {
+                self.lineno += 1;
                 return s;
             }
             s.push(ch);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,4 +173,33 @@ password hY5>yKqU&$vq&0
         let nrc = Netrc::from_file(fi.as_path()).unwrap();
         check_nrc(&nrc);
     }
+
+    #[test]
+    fn test_comment_lines_in_netrc() {
+        let content = "\
+machine localhost
+login user
+password abc12345
+
+# machine 127.0.0.1
+# login none
+# password PAT
+
+machine remote
+login root
+password fine
+";
+
+        let nrc: Netrc = content.parse().unwrap();
+
+        assert_eq!(nrc.hosts.len(), 2);
+
+        assert_eq!(nrc.hosts["localhost"].login, "user");
+        assert_eq!(nrc.hosts["localhost"].password, "abc12345");
+
+        assert_eq!(nrc.hosts["remote"].login, "root");
+        assert_eq!(nrc.hosts["remote"].password, "fine");
+
+        assert!(!nrc.hosts.contains_key("127.0.0.1"));
+    }
 }

--- a/src/netrc.rs
+++ b/src/netrc.rs
@@ -77,13 +77,14 @@ impl std::str::FromStr for Netrc {
         let mut lexer = Lex::new(s);
 
         loop {
-            let saved_lineno = lexer.lineno;
             let tt = lexer.get_token();
             if tt.is_empty() {
                 break;
             }
             if tt.chars().nth(0) == Some('#') {
-                if lexer.lineno == saved_lineno && tt.len() == 1 {
+                // If it's a standalone # (not part of a value like "#pass"),
+                // consume the rest of the line (if we're not already at a line boundary)
+                if !lexer.at_line_start && tt.len() == 1 {
                     lexer.read_line();
                 }
                 continue;
@@ -131,10 +132,11 @@ impl std::str::FromStr for Netrc {
             let mut auth = Authenticator::default();
 
             loop {
-                let prev_lineno = lexer.lineno;
                 let tt = lexer.get_token();
                 if tt.starts_with('#') {
-                    if lexer.lineno == prev_lineno {
+                    // If it's a standalone # (not part of a value like "#pass"),
+                    // consume the rest of the line (if we're not already at a line boundary)
+                    if !lexer.at_line_start && tt.len() == 1 {
                         lexer.read_line();
                     }
                     continue;


### PR DESCRIPTION
Resolves https://github.com/gribouille/netrc/issues/12

This PR introduces an `at_line_start` flag to the lexer so we can distinguish between `#` tokens that still have trailing content and those that already consumed the newline, then use that information in the parser to skip only the remainder of the current line for true comments while leaving values like `#pass` intact. 

The lexer update leverages `Option::is_some_and` for whitespace detection, `read_line` now keeps `lineno` in sync, and I've also added a test covering that comment-only lines no longer produce spurious machine entries.